### PR TITLE
añado apartado de conceptos iniciales

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ mejor las clases.
 
 ## Temario
 
+* Definición y conceptos (0'5 horas).
+  * Cloud computing como modelo de prestación de servicios.
 * Lenguajes de desarrollo moderno de aplicaciones (4 horas).
   * Javascript, Ruby, Perl 6 como lenguajes de scripting.
   * Go, Scala como lenguajes compilados.


### PR DESCRIPTION
Considero que algo que se echa en falta tanto en IV (grado) como en CC (máster) es una explicación inicial de que el cloud computing no es ya solo una forma de desarrollar y desplegar aplicaciones, sino que el fin último de este paradigma es establecer un modelo de negocio y prestación de servicios basado en la tecnología. Es algo que se acaba dando por sentado con el tiempo, pero que ayudaría mucho entender de primera mano antes de entrar en materia.